### PR TITLE
Fixed double counting notes

### DIFF
--- a/models/board.js
+++ b/models/board.js
@@ -186,7 +186,8 @@ var Board = Protected.extend({
 		var boards = [this.id()].concat(child_board_ids);
 		return turtl.search.search({boards: boards}).bind(this)
 			.spread(function(notes) {
-				return notes.length;
+			    var uniqueNotes  = notes.filter(function(v,i) { return i==notes.lastIndexOf(v); });
+			    return uniqueNotes.length;
 			});
 	},
 


### PR DESCRIPTION
A minor change that solves the issue of over-counting the number of notes in boards which have child boards.