### PR TITLE
Add a minify target to Makefile (concatenate js files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ index.html
 !reset.css
 library/templates.js
 library/svg-icons.js
+turtl.min.js
 *.stackdump
 

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,9 @@ clean:
 watch:
 	@./scripts/watch
 
+min.index.html: $(allcss) $(alljs) $(cssfiles) library/templates.js views/layouts/default.html .build/postcss scripts/include.sh scripts/gen-minified-index
+	@echo "- index.html: " $?
+	@./scripts/gen-minified-index
+
+
+minify: $(cssfiles) library/templates.js library/svg-icons.js .build/postcss min.index.html

--- a/scripts/gen-minified-index
+++ b/scripts/gen-minified-index
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+### This script generates index.html, which loads all needed javascript and
+### css for the app.
+
+pwd=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+ASSET_ROOT=""
+SEARCH_PATH=""
+source "$pwd/include.sh"
+
+## -----------------------------------------------------------------------------
+## generate extra
+## -----------------------------------------------------------------------------
+extra='<base href="/">'
+
+## -----------------------------------------------------------------------------
+## generate CSS links
+## -----------------------------------------------------------------------------
+css="$(
+	echo "$(all_css)" \
+		| sed 's|^|<link rel=\"stylesheet\" href=\"/|' \
+		| sed 's|$|">|'
+)"
+
+## -----------------------------------------------------------------------------
+## generate JS includes
+## -----------------------------------------------------------------------------
+js="$(
+	cat $(echo "$(all_js)" \
+		| sed 's|___| |g' \
+	) > turtl.min.js
+	echo '<script src="/turtl.min.js"></script>'
+)"
+
+## -----------------------------------------------------------------------------
+## put it all together
+## -----------------------------------------------------------------------------
+index="$(cat views/layouts/default.html)"
+index="$(do_replace "$index" '{{extra}}' "$extra")"
+index="$(do_replace "$index" '{{gencss}}' "$css")"
+index="$(do_replace "$index" '{{genjs}}' "$js")"
+
+# send our generated data into their restecpive files
+echo -ne "$index" > index.html
+


### PR DESCRIPTION
Chrome seems to load and eval js files to quickly and this ends to
evaluating js files before their dependencies, leading to errors like
`FormController is not defined`.

Concatenating js files forces the order of evaluation and solves the
problem. The concatenated turtl.min.js is heavy (about 2Mo) but after
the first load, this file is cached on the browser.