### PR TITLE
Added strikethrough to markdown help

### DIFF
--- a/views/help/markdown.hbs
+++ b/views/help/markdown.hbs
@@ -34,8 +34,8 @@
 			<div><a target="_blank" href="https://turtl.it/">{{t 'Making links</a> is easy!'}}</div>
 		</li>
 		<li>
-			<div>{{t 'You can also make text __bold__ or *italic*.'}}</div>
-			<div>{{t 'You can also make text <strong>bold</strong> or <em>italic</em>.'}}</div>
+			<div>{{t 'You can also make text __bold__, *italic* or ~~strikethrough~~.'}}</div>
+			<div>{{t 'You can also make text <strong>bold</strong>, <em>italic</em> or <strike>strikethrough</strike>.'}}</div>
 		</li>
 		<li>
 			<div>{{t 'Here\'s an image:<br>![](https://turtl.it/images<space> </space>/favicon.png)'}}</div>


### PR DESCRIPTION
The markdown help didn't contain any instructions about strikethrough text. This adds it.

![screenshot from 2017-01-20 10-08-38](https://cloud.githubusercontent.com/assets/8016438/22154166/736b170e-def8-11e6-9027-7d5238288a8a.png)

Also, I'd love a little info on how translation works, because these changes will not work on other locales.